### PR TITLE
Caught Nullpointer in Reference Extension

### DIFF
--- a/Core/org.emftext.language.java/src/org/emftext/language/java/extensions/references/ReferenceExtension.java
+++ b/Core/org.emftext.language.java/src/org/emftext/language/java/extensions/references/ReferenceExtension.java
@@ -105,7 +105,6 @@ public class ReferenceExtension {
 			if (target == null) {
 				return null;
 			}
-				return null;
 			if (target.eIsProxy()) {
 				type = null;
 			}

--- a/Core/org.emftext.language.java/src/org/emftext/language/java/extensions/references/ReferenceExtension.java
+++ b/Core/org.emftext.language.java/src/org/emftext/language/java/extensions/references/ReferenceExtension.java
@@ -101,6 +101,9 @@ public class ReferenceExtension {
 		else if (me instanceof ElementReference) {
 			ReferenceableElement target = 
 				(ReferenceableElement) ((ElementReference) me).getTarget();
+			
+			if(target == null)
+				return null;
 			if (target.eIsProxy()) {
 				type = null;
 			}

--- a/Core/org.emftext.language.java/src/org/emftext/language/java/extensions/references/ReferenceExtension.java
+++ b/Core/org.emftext.language.java/src/org/emftext/language/java/extensions/references/ReferenceExtension.java
@@ -102,7 +102,9 @@ public class ReferenceExtension {
 			ReferenceableElement target = 
 				(ReferenceableElement) ((ElementReference) me).getTarget();
 			
-			if(target == null)
+			if (target == null) {
+				return null;
+			}
 				return null;
 			if (target.eIsProxy()) {
 				type = null;


### PR DESCRIPTION
Caught a nullpointer exception that would occur whenever an ElementReference's target is not set (is null).